### PR TITLE
Lab 5C concurrent config changes

### DIFF
--- a/src/shardkv1/client.go
+++ b/src/shardkv1/client.go
@@ -76,6 +76,10 @@ func (ck *Clerk) Get(key string) (string, rpc.Tversion, rpc.Err) {
 func (ck *Clerk) tryGetValue(shard shardcfg.Tshid, key string) (string, rpc.Tversion, rpc.Err) {
 	grpClerk := ck.getClerkForShard(shard)
 
+	if grpClerk == nil {
+		return "", 0, rpc.ErrWrongGroup
+	}
+
 	return grpClerk.Get(key)
 }
 
@@ -119,25 +123,33 @@ func (ck *Clerk) Put(key string, value string, version rpc.Tversion) rpc.Err {
 func (ck *Clerk) tryPutValue(shard shardcfg.Tshid, key string, value string, version rpc.Tversion) rpc.Err {
 	grpClerk := ck.getClerkForShard(shard)
 
+	if grpClerk == nil {
+		return rpc.ErrWrongGroup
+	}
+
 	return grpClerk.Put(key, value, version)
 }
 
 func (ck *Clerk) getClerkForShard(shard shardcfg.Tshid) *shardgrp.Clerk {
 	cfg := ck.sck.Query()
+	utils.DPrintf("[getClerkForShard] Queried config: %v", cfg)
 	gid := cfg.Shards[shard]
 
 	ck.clerksLock.Lock()
+	defer ck.clerksLock.Unlock()
+
 	grpClerk, ok := ck.grpClerks[gid]
 	if !ok {
 		servers, ok := cfg.Groups[gid]
 		if !ok {
-			panic("no group for shard")
+			utils.DPrintf("[getClerkForShard] No group found for gid %v, shard %v", gid, shard)
+
+			return nil
 		}
 
 		grpClerk = shardgrp.MakeClerk(ck.clnt, servers)
 		ck.grpClerks[gid] = grpClerk
 	}
-	ck.clerksLock.Unlock()
 
 	return grpClerk
 }

--- a/src/shardkv1/shardctrler/shardctrler.go
+++ b/src/shardkv1/shardctrler/shardctrler.go
@@ -5,6 +5,11 @@ package shardctrler
 //
 
 import (
+	"fmt"
+	"math"
+	"sync/atomic"
+	"time"
+
 	kvsrv "6.5840/kvsrv1"
 	"6.5840/kvsrv1/rpc"
 	kvtest "6.5840/kvtest1"
@@ -12,12 +17,12 @@ import (
 	"6.5840/shardkv1/shardgrp"
 	"6.5840/shardkv1/utils"
 	tester "6.5840/tester1"
+	"github.com/google/uuid"
 )
 
 const (
-	INITIAL_CONFIG_VERSION = 0
-	CONFIG_KEY             = "config"
-	NEXT_CONFIG_KEY        = "nextConfig"
+	CONFIG_KEY      = "config"
+	NEXT_CONFIG_KEY = "nextConfig"
 )
 
 // ShardCtrler for the controller and kv clerk.
@@ -28,6 +33,8 @@ type ShardCtrler struct {
 	killed int32 // set by Kill()
 
 	// Your data here.
+	lastConfig atomic.Pointer[shardcfg.ShardConfig]
+	me         uuid.UUID
 }
 
 type Transfer struct {
@@ -42,6 +49,11 @@ func MakeShardCtrler(clnt *tester.Clnt) *ShardCtrler {
 	sck := &ShardCtrler{clnt: clnt}
 	srv := tester.ServerName(tester.GRP0, 0)
 	sck.IKVClerk = kvsrv.MakeClerk(clnt, srv)
+	sck.lastConfig = atomic.Pointer[shardcfg.ShardConfig]{}
+	sck.lastConfig.Store(shardcfg.MakeShardConfig())
+	sck.me = uuid.New()
+	utils.DPrintf("[%s] Updated last config in memory to %v", sck.me, sck.lastConfig.Load())
+
 	// Your code here.
 	return sck
 }
@@ -59,6 +71,11 @@ func (sck *ShardCtrler) InitController() {
 	if curErr == rpc.ErrNoKey && curErr == nextErr {
 		utils.DPrintf("[schrdctrler] InitController: both current and next config not found, starting with empty state")
 		return
+	}
+
+	if curErr == rpc.OK {
+		sck.lastConfig.Store(shardcfg.FromString(value))
+		utils.DPrintf("[%s] Updated last config in memory to %v", sck.me, sck.lastConfig.Load())
 	}
 
 	if curVersion == nextVersion {
@@ -82,7 +99,12 @@ func (sck *ShardCtrler) InitController() {
 func (sck *ShardCtrler) InitConfig(cfg *shardcfg.ShardConfig) {
 	//OK, ErrVersion, ErrMaybe
 
-	utils.DPrintf("[schrdctrler] InitConfig: putting initial config %v\n", cfg.String())
+	utils.DPrintf("[schrdctrler][%s] InitConfig: putting initial config %v\n", sck.me, cfg.String())
+
+	sck.lastConfig.Store(cfg)
+	utils.DPrintf("[%s] Updated last config in memory to %v", sck.me, sck.lastConfig.Load())
+
+	// panic("InitConfig: not implemented yet") // You can delete this line.
 
 	sck.ChangeConfigTo(cfg)
 }
@@ -101,23 +123,35 @@ func (sck *ShardCtrler) ChangeConfigTo(new *shardcfg.ShardConfig) {
 		utils.DPrintf("[schrdctrler] Query[next]: get value %v version %v err %v", nextValue, nextVersion, nextErr)
 
 		if curErr == rpc.ErrNoKey && curErr == nextErr {
-			utils.DPrintf("[schrdctrler] InitController: both current and next config not found, starting with empty state")
+			utils.DPrintf("[schrdctrler] ChangeConfigTo: both current and next config not found, starting with empty state")
 
 			err := sck.handleBothEmptyConfig(new)
 			if err != rpc.OK {
-				utils.DPrintf("[schrdctrler] InitController: failed to handle both empty config, err = %v, retrying", err)
+				utils.DPrintf("[schrdctrler] ChangeConfigTo: failed to handle both empty config, err = %v, retrying", err)
 				continue
 			}
 
 			return
 		}
 
-		if curErr == rpc.ErrNoKey && nextErr == rpc.OK {
-			utils.DPrintf("[schrdctrler] InitController: no current config found, but next config found, setting current config to next config value")
+		// the next version should be non-decreasing
+		if nextErr == rpc.OK && (rpc.Tversion)(new.Num) < nextVersion {
+			utils.DPrintf("[schrdctrler] ChangeConfigTo: next config version %v is greater than new config version %v, returning", nextVersion, new.Num)
 
-			err := sck.handleNoCurrentNextExists(new)
+			return
+		}
+
+		if curErr == rpc.ErrNoKey && nextErr == rpc.OK {
+			utils.DPrintf("[schrdctrler]ChangeConfigTo: no current config found, but next config found, setting current config to next config value")
+
+			if (rpc.Tversion)(new.Num) > nextVersion {
+				utils.DPrintf("[sahrdctrler] ChangeConfigTo: next config version %v equals new config version %v, but the old controller is still in progress. Need to retry", nextVersion, new.Num)
+				continue
+			}
+
+			err := sck.handleNoCurrentNextExists(shardcfg.FromString(nextValue))
 			if err != rpc.OK {
-				utils.DPrintf("[schrdctrler] InitController: failed to handle no current config but next config exists, err = %v, retrying", err)
+				utils.DPrintf("[schrdctrler] ChangeConfigTo: failed to handle no current config but next config exists, err = %v, retrying", err)
 				continue
 			}
 
@@ -125,84 +159,111 @@ func (sck *ShardCtrler) ChangeConfigTo(new *shardcfg.ShardConfig) {
 		}
 
 		if curVersion == nextVersion {
-			utils.DPrintf("[schrdctrler] InitController: cur version %v equals next version %v. The last operation was successful.", curVersion, nextVersion)
-			err := sck.handleSameVersions(shardcfg.FromString(value), new, curVersion, nextVersion)
+			utils.DPrintf("[schrdctrler] ChangeConfigTo: cur version %v equals next version %v. The last operation was successful.", curVersion, nextVersion)
+
+			if (rpc.Tversion)(new.Num) == nextVersion {
+				utils.DPrintf("[sahrdctrler] ChangeConfigTo: next config version %v equals new config version %v. Both current and next config are in sync. Noting to do. Returning.", nextVersion, new.Num)
+
+				return
+			}
+
+			err := sck.handleSameVersions(shardcfg.FromString(value), new)
 			if err != rpc.OK {
-				utils.DPrintf("[schrdctrler] InitController: failed to handle same versions, err = %v, retrying", err)
+				utils.DPrintf("[schrdctrler] ChangeConfigTo: failed to handle same versions, err = %v, retrying", err)
 				continue
 			}
 
 			return
 		}
 
-		if curVersion != nextVersion {
-			utils.DPrintf("[schrdctrler] InitController: current and next config found, but versions are different, recovering by transfering shards according to the next config and then set current config to next config")
-			err := sck.handleDifferentVersions(shardcfg.FromString(value), new, curVersion)
+		if curVersion == nextVersion-1 {
+			utils.DPrintf("[schrdctrler] ChangeConfigTo: current and next config found, but versions are different, recovering by transfering shards according to the next config and then set current config to next config")
+
+			err := sck.handleDifferentVersions(shardcfg.FromString(value), shardcfg.FromString(nextValue))
 			if err != rpc.OK {
-				utils.DPrintf("[schrdctrler] InitController: failed to handle different versions, err = %v, retrying", err)
+				utils.DPrintf("[schrdctrler] ChangeConfigTo: failed to handle different versions, err = %v, retrying", err)
 				continue
 			}
 
 			return
 		}
 
-		panic("InitController: unexpected case where current and next config versions are different but not covered by the previous cases, idk how to handle it yet")
+		if math.Abs(float64(curVersion-nextVersion)) > 1 {
+			panic(fmt.Sprintf("ChangeConfigTo: Corrupted state. Current: %v, Next: %v", curVersion, nextVersion))
+
+		}
+
+		panic(fmt.Sprintf("ChangeConfigTo: unexpected case where current and next config versions are different but not covered by the previous cases, idk how to handle it yet. Current: %v, Next: %v", curVersion, nextVersion))
 	}
 }
 
 func (sck *ShardCtrler) handleBothEmptyConfig(new *shardcfg.ShardConfig) rpc.Err {
-	err := sck.setCofnigValueByKey(NEXT_CONFIG_KEY, shardcfg.FromString(new.String()), INITIAL_CONFIG_VERSION)
+	newVersion := (rpc.Tversion)(new.Num - 1)
+
+	err := sck.setCofnigValueByKey(NEXT_CONFIG_KEY, new, newVersion)
 	if err != rpc.OK {
-		utils.DPrintf("[schrdctrler] InitController: failed to set next config value, err = %v, retrying", err)
+		utils.DPrintf("[schrdctrler][%s] handleBothEmptyConfig: failed to set next config value, err = %v, retrying", sck.me, err)
 		return err
 	}
-	err = sck.setCofnigValueByKey(CONFIG_KEY, shardcfg.FromString(new.String()), INITIAL_CONFIG_VERSION)
+
+	err = sck.setCofnigValueByKey(CONFIG_KEY, new, newVersion)
 	if err != rpc.OK {
-		utils.DPrintf("[schrdctrler] InitController: failed to set current config value, err = %v, retrying", err)
+		utils.DPrintf("[schrdctrler][%s] handleBothEmptyConfig: failed to set current config value, err = %v, retrying", sck.me, err)
 		return err
 	}
+
 	return rpc.OK
 }
 
 func (sck *ShardCtrler) handleNoCurrentNextExists(new *shardcfg.ShardConfig) rpc.Err {
-	err := sck.setCofnigValueByKey(CONFIG_KEY, new, INITIAL_CONFIG_VERSION)
+	newVersion := (rpc.Tversion)(new.Num - 1)
+
+	err := sck.setCofnigValueByKey(CONFIG_KEY, new, newVersion)
 	if err != rpc.OK {
-		utils.DPrintf("[schrdctrler] InitController: failed to set current config value, err = %v, retrying", err)
+		utils.DPrintf("[schrdctrler][%s] handleNoCurrentNextExists: failed to set current config value, err = %v, retrying", sck.me, err)
 		return err
 	}
 
 	return rpc.OK
 }
 
-func (sck *ShardCtrler) handleSameVersions(old, new *shardcfg.ShardConfig, curVersion, nextVersion rpc.Tversion) rpc.Err {
-	err := sck.setCofnigValueByKey(NEXT_CONFIG_KEY, new, nextVersion)
+func (sck *ShardCtrler) handleSameVersions(old, new *shardcfg.ShardConfig) rpc.Err {
+	version := (rpc.Tversion)(new.Num - 1)
+
+	err := sck.setCofnigValueByKey(NEXT_CONFIG_KEY, new, version)
 	if err != rpc.OK {
-		utils.DPrintf("[schrdctrler] InitController: failed to set next config value, err = %v, retrying", err)
+		utils.DPrintf("[schrdctrler][%s] handleSameVersions: failed to set next config value, err = %v, retrying", sck.me, err)
 		return err
 	}
+
 	err = sck.transferShards(old, new)
 	if err != rpc.OK {
-		utils.DPrintf("[schrdctrler] InitController: failed to transfer shards for new config, err = %v, retrying", err)
+		utils.DPrintf("[schrdctrler][%s] handleSameVersions: failed to transfer shards for new config, err = %v, retrying", sck.me, err)
 		return err
 	}
-	err = sck.setCofnigValueByKey(CONFIG_KEY, new, curVersion)
+
+	err = sck.setCofnigValueByKey(CONFIG_KEY, new, version)
 	if err != rpc.OK {
-		utils.DPrintf("[schrdctrler] InitController: failed to set current config value, err = %v, retrying", err)
+		utils.DPrintf("[schrdctrler][%s] handleSameVersions: failed to set current config value, err = %v, retrying", sck.me, err)
 		return err
 	}
 
 	return rpc.OK
 
 }
-func (sck *ShardCtrler) handleDifferentVersions(old, new *shardcfg.ShardConfig, curVersion rpc.Tversion) rpc.Err {
+func (sck *ShardCtrler) handleDifferentVersions(old, new *shardcfg.ShardConfig) rpc.Err {
+	newVersion := (rpc.Tversion)(new.Num - 1)
+	curVersion := newVersion
+
 	err := sck.transferShards(old, new)
 	if err != rpc.OK {
-		utils.DPrintf("[schrdctrler] InitController: failed to transfer shards for new config, err = %v, retrying", err)
+		utils.DPrintf("[schrdctrler][%s] handleDifferentVersions: failed to transfer shards for new config, err = %v, retrying", sck.me, err)
 		return err
 	}
+
 	err = sck.setCofnigValueByKey(CONFIG_KEY, new, curVersion)
 	if err != rpc.OK {
-		utils.DPrintf("[schrdctrler] InitController: failed to set current config value, err = %v, retrying", err)
+		utils.DPrintf("[schrdctrler][%s] handleDifferentVersions: failed to set current config value, err = %v, retrying", sck.me, err)
 		return err
 	}
 
@@ -210,14 +271,19 @@ func (sck *ShardCtrler) handleDifferentVersions(old, new *shardcfg.ShardConfig, 
 }
 
 func (sck *ShardCtrler) setCofnigValueByKey(key string, config *shardcfg.ShardConfig, version rpc.Tversion) rpc.Err {
+	if key == CONFIG_KEY {
+		sck.lastConfig.Store(config)
+		utils.DPrintf("[schrdctrler][%s] Updated last config in memory to %v", sck.me, sck.lastConfig.Load())
+	}
+
 	err := sck.tryPutValueWithRetires(key, config.String(), version)
 	if err == rpc.OK {
-		utils.DPrintf("[schrdctrler] Successfully put %s config with version %v", key, version)
+		utils.DPrintf("[schrdctrler][%s] Successfully put %s config with version %v", sck.me, key, version)
 
 		return err
 	}
 
-	utils.DPrintf("[schrdctrler] Failed to put %s config with version %v, err = %v, retrying", key, version, err)
+	utils.DPrintf("[schrdctrler][%s] Failed to put %s config with version %v, err = %v, retrying", sck.me, key, version, err)
 
 	return err
 }
@@ -339,7 +405,7 @@ func (sck *ShardCtrler) tryPutValueWithRetires(key, value string, version rpc.Tv
 		retries++
 	}
 
-	utils.DPrintf("[schrdctrler] tryPutValueWithRetires: done trying to put value %v with err %v after %d retries", value, err, retries)
+	utils.DPrintf("[schrdctrler][%s] tryPutValueWithRetires: done trying to put value %v with err %v after %d retries", sck.me, value, err, retries)
 
 	return err
 }
@@ -347,12 +413,45 @@ func (sck *ShardCtrler) tryPutValueWithRetires(key, value string, version rpc.Tv
 // Return the current configuration
 func (sck *ShardCtrler) Query() *shardcfg.ShardConfig {
 	// Your code here.
+
+	done := make(chan *shardcfg.ShardConfig, 1)
+	go func() {
+		done <- sck.loadConfigFromKvSrv()
+	}()
+
+	timer := time.NewTimer(50 * time.Millisecond)
+	defer timer.Stop()
+
+	for {
+		select {
+		case cfg := <-done:
+			if cfg != nil {
+				utils.DPrintf("[schrdctrler][%s] Query: got config from kvsrv: %v", sck.me, cfg)
+				return cfg
+			}
+
+			cfg = sck.lastConfig.Load()
+			utils.DPrintf("[schrdctrler][%s] Query: failed to get config from kvsrv, returning last config in memory: %v", sck.me, cfg)
+
+			return cfg
+		case <-timer.C:
+			cfg := sck.lastConfig.Load()
+			utils.DPrintf("[schrdctrler][%s] Query: timeout while getting config from kvsrv, returning last config in memory: %v", sck.me, cfg)
+
+			return cfg
+		}
+	}
+}
+
+func (sck *ShardCtrler) loadConfigFromKvSrv() *shardcfg.ShardConfig {
 	value, version, err := sck.Get(CONFIG_KEY)
-	utils.DPrintf("Query: get value %v version %v err %v", value, version, err)
+	utils.DPrintf("[schrdctrler][%s] loadConfigFromKvSrv: get value %v version %v err %v", sck.me, value, version, err)
 
 	if err == rpc.OK {
 		return shardcfg.FromString(value)
 	}
+
+	utils.DPrintf("[schrdctrler][%s] loadConfigFromKvSrv: failed to get config from kvsrv, returning nil", sck.me)
 
 	return nil
 }

--- a/src/shardkv1/shardctrler/shardctrler.go
+++ b/src/shardkv1/shardctrler/shardctrler.go
@@ -7,6 +7,7 @@ package shardctrler
 import (
 	"fmt"
 	"math"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -32,9 +33,7 @@ type ShardCtrler struct {
 
 	killed int32 // set by Kill()
 
-	// Your data here.
-	lastConfig atomic.Pointer[shardcfg.ShardConfig]
-	me         uuid.UUID
+	me uuid.UUID
 }
 
 type Transfer struct {
@@ -49,10 +48,7 @@ func MakeShardCtrler(clnt *tester.Clnt) *ShardCtrler {
 	sck := &ShardCtrler{clnt: clnt}
 	srv := tester.ServerName(tester.GRP0, 0)
 	sck.IKVClerk = kvsrv.MakeClerk(clnt, srv)
-	sck.lastConfig = atomic.Pointer[shardcfg.ShardConfig]{}
-	sck.lastConfig.Store(shardcfg.MakeShardConfig())
 	sck.me = uuid.New()
-	utils.DPrintf("[%s] Updated last config in memory to %v", sck.me, sck.lastConfig.Load())
 
 	// Your code here.
 	return sck
@@ -63,27 +59,22 @@ func MakeShardCtrler(clnt *tester.Clnt) *ShardCtrler {
 // B and C, this method implements recovery.
 func (sck *ShardCtrler) InitController() {
 	value, curVersion, curErr := sck.Get(CONFIG_KEY)
-	utils.DPrintf("[schrdctrler] Query[cur]: get value %v version %v err %v", value, curVersion, curErr)
+	utils.DPrintf("[schrdctrler][%s]  Query[cur]: get value %v version %v err %v", sck.me, value, curVersion, curErr)
 
 	nextValue, nextVersion, nextErr := sck.Get(NEXT_CONFIG_KEY)
-	utils.DPrintf("[schrdctrler] Query[next]: get value %v version %v err %v", nextValue, nextVersion, nextErr)
+	utils.DPrintf("[schrdctrler][%s] Query[next]: get value %v version %v err %v", sck.me, nextValue, nextVersion, nextErr)
 
 	if curErr == rpc.ErrNoKey && curErr == nextErr {
-		utils.DPrintf("[schrdctrler] InitController: both current and next config not found, starting with empty state")
+		utils.DPrintf("[schrdctrler][%s] InitController: both current and next config not found, starting with empty state", sck.me)
 		return
-	}
-
-	if curErr == rpc.OK {
-		sck.lastConfig.Store(shardcfg.FromString(value))
-		utils.DPrintf("[%s] Updated last config in memory to %v", sck.me, sck.lastConfig.Load())
 	}
 
 	if curVersion == nextVersion {
-		utils.DPrintf("[schrdctrler] InitController: cur version %v equals next version %v. The last operation was successful.", curVersion, nextVersion)
+		utils.DPrintf("[schrdctrler][%s] InitController: cur version %v equals next version %v. The last operation was successful.", sck.me, curVersion, nextVersion)
 		return
 	}
 
-	utils.DPrintf("[schrdctrler] InitController: current and next configs are not in sync, need to recover")
+	utils.DPrintf("[schrdctrler][%s] InitController: current and next configs are not in sync, need to recover", sck.me)
 
 	// two cases here
 	// 1. no config, next config found - we start with empty state, need to set current config to next config value
@@ -97,15 +88,6 @@ func (sck *ShardCtrler) InitController() {
 // pick the key to name the configuration.  The initial configuration
 // lists shardgrp shardcfg.Gid1 for all shards.
 func (sck *ShardCtrler) InitConfig(cfg *shardcfg.ShardConfig) {
-	//OK, ErrVersion, ErrMaybe
-
-	utils.DPrintf("[schrdctrler][%s] InitConfig: putting initial config %v\n", sck.me, cfg.String())
-
-	sck.lastConfig.Store(cfg)
-	utils.DPrintf("[%s] Updated last config in memory to %v", sck.me, sck.lastConfig.Load())
-
-	// panic("InitConfig: not implemented yet") // You can delete this line.
-
 	sck.ChangeConfigTo(cfg)
 }
 
@@ -117,17 +99,17 @@ func (sck *ShardCtrler) ChangeConfigTo(new *shardcfg.ShardConfig) {
 	// Your code here.
 	for {
 		value, curVersion, curErr := sck.Get(CONFIG_KEY)
-		utils.DPrintf("[schrdctrler] Query[cur]: get value %v version %v err %v", value, curVersion, curErr)
+		utils.DPrintf("[schrdctrler][%s] ChangeConfigTo Query[cur]: get value %v version %v err %v", sck.me, value, curVersion, curErr)
 
 		nextValue, nextVersion, nextErr := sck.Get(NEXT_CONFIG_KEY)
-		utils.DPrintf("[schrdctrler] Query[next]: get value %v version %v err %v", nextValue, nextVersion, nextErr)
+		utils.DPrintf("[schrdctrler][%s] ChangeConfigTo Query[next]: get value %v version %v err %v", sck.me, nextValue, nextVersion, nextErr)
 
 		if curErr == rpc.ErrNoKey && curErr == nextErr {
-			utils.DPrintf("[schrdctrler] ChangeConfigTo: both current and next config not found, starting with empty state")
+			utils.DPrintf("[schrdctrler][%s] ChangeConfigTo: both current and next config not found, starting with empty state", sck.me)
 
 			err := sck.handleBothEmptyConfig(new)
 			if err != rpc.OK {
-				utils.DPrintf("[schrdctrler] ChangeConfigTo: failed to handle both empty config, err = %v, retrying", err)
+				utils.DPrintf("[schrdctrler][%s] ChangeConfigTo: failed to handle both empty config, err = %v, retrying", sck.me, err)
 				continue
 			}
 
@@ -136,22 +118,22 @@ func (sck *ShardCtrler) ChangeConfigTo(new *shardcfg.ShardConfig) {
 
 		// the next version should be non-decreasing
 		if nextErr == rpc.OK && (rpc.Tversion)(new.Num) < nextVersion {
-			utils.DPrintf("[schrdctrler] ChangeConfigTo: next config version %v is greater than new config version %v, returning", nextVersion, new.Num)
+			utils.DPrintf("[schrdctrler][%s] ChangeConfigTo: next config version %v is greater than new config version %v, returning", sck.me, nextVersion, new.Num)
 
 			return
 		}
 
 		if curErr == rpc.ErrNoKey && nextErr == rpc.OK {
-			utils.DPrintf("[schrdctrler]ChangeConfigTo: no current config found, but next config found, setting current config to next config value")
+			utils.DPrintf("[schrdctrler][%s] ChangeConfigTo: no current config found, but next config found, setting current config to next config value", sck.me)
 
 			if (rpc.Tversion)(new.Num) > nextVersion {
-				utils.DPrintf("[sahrdctrler] ChangeConfigTo: next config version %v equals new config version %v, but the old controller is still in progress. Need to retry", nextVersion, new.Num)
+				utils.DPrintf("[sahrdctrler][%s] ChangeConfigTo: next config version %v equals new config version %v, but the old controller is still in progress. Need to retry", sck.me, nextVersion, new.Num)
 				continue
 			}
 
 			err := sck.handleNoCurrentNextExists(shardcfg.FromString(nextValue))
 			if err != rpc.OK {
-				utils.DPrintf("[schrdctrler] ChangeConfigTo: failed to handle no current config but next config exists, err = %v, retrying", err)
+				utils.DPrintf("[schrdctrler][%s] ChangeConfigTo: failed to handle no current config but next config exists, err = %v, retrying", sck.me, err)
 				continue
 			}
 
@@ -159,17 +141,17 @@ func (sck *ShardCtrler) ChangeConfigTo(new *shardcfg.ShardConfig) {
 		}
 
 		if curVersion == nextVersion {
-			utils.DPrintf("[schrdctrler] ChangeConfigTo: cur version %v equals next version %v. The last operation was successful.", curVersion, nextVersion)
+			utils.DPrintf("[schrdctrler][%s] ChangeConfigTo: cur version %v equals next version %v. The last operation was successful.", sck.me, curVersion, nextVersion)
 
 			if (rpc.Tversion)(new.Num) == nextVersion {
-				utils.DPrintf("[sahrdctrler] ChangeConfigTo: next config version %v equals new config version %v. Both current and next config are in sync. Noting to do. Returning.", nextVersion, new.Num)
+				utils.DPrintf("[sahrdctrler][%s] ChangeConfigTo: next config version %v equals new config version %v. Both current and next config are in sync. Noting to do. Returning.", sck.me, nextVersion, new.Num)
 
 				return
 			}
 
 			err := sck.handleSameVersions(shardcfg.FromString(value), new)
 			if err != rpc.OK {
-				utils.DPrintf("[schrdctrler] ChangeConfigTo: failed to handle same versions, err = %v, retrying", err)
+				utils.DPrintf("[schrdctrler][%s] ChangeConfigTo: failed to handle same versions, err = %v, retrying", sck.me, err)
 				continue
 			}
 
@@ -177,11 +159,11 @@ func (sck *ShardCtrler) ChangeConfigTo(new *shardcfg.ShardConfig) {
 		}
 
 		if curVersion == nextVersion-1 {
-			utils.DPrintf("[schrdctrler] ChangeConfigTo: current and next config found, but versions are different, recovering by transfering shards according to the next config and then set current config to next config")
+			utils.DPrintf("[schrdctrler][%s] ChangeConfigTo: current and next config found, but versions are different, recovering by transfering shards according to the next config and then set current config to next config", sck.me)
 
 			err := sck.handleDifferentVersions(shardcfg.FromString(value), shardcfg.FromString(nextValue))
 			if err != rpc.OK {
-				utils.DPrintf("[schrdctrler] ChangeConfigTo: failed to handle different versions, err = %v, retrying", err)
+				utils.DPrintf("[schrdctrler][%s] ChangeConfigTo: failed to handle different versions, err = %v, retrying", sck.me, err)
 				continue
 			}
 
@@ -271,11 +253,6 @@ func (sck *ShardCtrler) handleDifferentVersions(old, new *shardcfg.ShardConfig) 
 }
 
 func (sck *ShardCtrler) setCofnigValueByKey(key string, config *shardcfg.ShardConfig, version rpc.Tversion) rpc.Err {
-	if key == CONFIG_KEY {
-		sck.lastConfig.Store(config)
-		utils.DPrintf("[schrdctrler][%s] Updated last config in memory to %v", sck.me, sck.lastConfig.Load())
-	}
-
 	err := sck.tryPutValueWithRetires(key, config.String(), version)
 	if err == rpc.OK {
 		utils.DPrintf("[schrdctrler][%s] Successfully put %s config with version %v", sck.me, key, version)
@@ -291,12 +268,12 @@ func (sck *ShardCtrler) setCofnigValueByKey(key string, config *shardcfg.ShardCo
 func (sck *ShardCtrler) transferShards(old, new *shardcfg.ShardConfig) rpc.Err {
 	err := sck.tryTransferShards(old, new)
 	if err == rpc.OK {
-		utils.DPrintf("[schrdctrler] Successfully transfered shards for new cofnig")
+		utils.DPrintf("[schrdctrler][%s]  Successfully transfered shards for new cofnig", sck.me)
 
 		return err
 	}
 
-	utils.DPrintf("[schrdctrler] Failed to transfer shards for new config, err = %v, retrying", err)
+	utils.DPrintf("[schrdctrler][%s] Failed to transfer shards for new config, err = %v, retrying", sck.me, err)
 
 	return err
 }
@@ -304,40 +281,48 @@ func (sck *ShardCtrler) transferShards(old, new *shardcfg.ShardConfig) rpc.Err {
 func (sck *ShardCtrler) tryTransferShards(old, new *shardcfg.ShardConfig) rpc.Err {
 	transfers := sck.prepareTransfers(old, new)
 
-	// wg := sync.WaitGroup{}
-	// wg.Add(len(transfers))
-	var err rpc.Err
+	wg := sync.WaitGroup{}
+	wg.Add(len(transfers))
+
+	firstErr := atomic.Pointer[rpc.Err]{}
+	ok := (rpc.Err)(rpc.OK)
+	firstErr.Store(&ok)
+
 	for _, transfer := range transfers {
-		// go func() {
-		// defer wg.Done()
-		err = sck.freezeShard(old, new, &transfer)
-		if err != rpc.OK {
-			utils.DPrintf("[schrdctrler] Failed to freeze shards")
+		go func(transfer Transfer) {
+			defer wg.Done()
+			utils.DPrintf("[schrdctrler][%s] Starting transfer for shard %d from group %d to group %d", sck.me, transfer.shId, transfer.fromG, transfer.toG)
+			err := sck.freezeShard(old, new, &transfer)
+			if err != rpc.OK {
+				utils.DPrintf("[schrdctrler][%s] Failed to freeze shards", sck.me)
 
-			return err
-		}
+				firstErr.CompareAndSwap(&ok, &err)
+				return
+			}
 
-		err = sck.installShard(new, transfer)
-		if err != rpc.OK {
-			utils.DPrintf("[schrdctrler] Failed to install shards")
+			err = sck.installShard(new, transfer)
+			if err != rpc.OK {
+				utils.DPrintf("[schrdctrler][%s] Failed to install shards", sck.me)
 
-			return err
-		}
+				firstErr.CompareAndSwap(&ok, &err)
+				return
+			}
 
-		err = sck.deleteShards(old, new, transfer)
-		if err != rpc.OK {
-			utils.DPrintf("[schrdctrler] Failed to delete shards")
+			err = sck.deleteShards(old, new, transfer)
+			if err != rpc.OK {
+				utils.DPrintf("[schrdctrler][%s] Failed to delete shards", sck.me)
 
-			return err
-		}
-
-		// return rpc.OK
-		// }()
+				firstErr.CompareAndSwap(&ok, &err)
+				return
+			}
+		}(transfer)
 	}
 
-	// wg.Wait()
+	wg.Wait()
 
-	return rpc.OK
+	utils.DPrintf("[schrdctrler][%s] Finished all transfers for new config, first error: %v", sck.me, *firstErr.Load())
+
+	return *firstErr.Load()
 }
 
 func (sck *ShardCtrler) prepareTransfers(oldConfig, newConfig *shardcfg.ShardConfig) []Transfer {
@@ -413,45 +398,15 @@ func (sck *ShardCtrler) tryPutValueWithRetires(key, value string, version rpc.Tv
 // Return the current configuration
 func (sck *ShardCtrler) Query() *shardcfg.ShardConfig {
 	// Your code here.
-
-	done := make(chan *shardcfg.ShardConfig, 1)
-	go func() {
-		done <- sck.loadConfigFromKvSrv()
-	}()
-
-	timer := time.NewTimer(50 * time.Millisecond)
-	defer timer.Stop()
-
 	for {
-		select {
-		case cfg := <-done:
-			if cfg != nil {
-				utils.DPrintf("[schrdctrler][%s] Query: got config from kvsrv: %v", sck.me, cfg)
-				return cfg
-			}
+		value, version, err := sck.Get(CONFIG_KEY)
+		utils.DPrintf("[schrdctrler][%s] loadConfigFromKvSrv: get value %v version %v err %v", sck.me, value, version, err)
 
-			cfg = sck.lastConfig.Load()
-			utils.DPrintf("[schrdctrler][%s] Query: failed to get config from kvsrv, returning last config in memory: %v", sck.me, cfg)
-
-			return cfg
-		case <-timer.C:
-			cfg := sck.lastConfig.Load()
-			utils.DPrintf("[schrdctrler][%s] Query: timeout while getting config from kvsrv, returning last config in memory: %v", sck.me, cfg)
-
-			return cfg
+		if err == rpc.OK {
+			return shardcfg.FromString(value)
 		}
+
+		utils.DPrintf("[schrdctrler][%s] loadConfigFromKvSrv: failed to get config from kvsrv, retrying...", sck.me)
+		time.Sleep(250 * time.Millisecond)
 	}
-}
-
-func (sck *ShardCtrler) loadConfigFromKvSrv() *shardcfg.ShardConfig {
-	value, version, err := sck.Get(CONFIG_KEY)
-	utils.DPrintf("[schrdctrler][%s] loadConfigFromKvSrv: get value %v version %v err %v", sck.me, value, version, err)
-
-	if err == rpc.OK {
-		return shardcfg.FromString(value)
-	}
-
-	utils.DPrintf("[schrdctrler][%s] loadConfigFromKvSrv: failed to get config from kvsrv, returning nil", sck.me)
-
-	return nil
 }

--- a/src/shardkv1/shardgrp/client.go
+++ b/src/shardkv1/shardgrp/client.go
@@ -14,7 +14,7 @@ import (
 type NetworkReply int
 
 const (
-	rpcTimeout = 3
+	rpcTimeout = 1500 // in milliseconds
 
 	TIMEOUT NetworkReply = iota
 	DISCONNECT
@@ -36,8 +36,8 @@ func MakeClerk(clnt *tester.Clnt, servers []string) *Clerk {
 	return ck
 }
 
-func (ck *Clerk) callGet(s int32, args *rpc.GetArgs, reply *rpc.GetReply) (NetworkReply, rpc.Err) {
-	deadline := time.After(rpcTimeout * time.Second)
+func (ck *Clerk) callGet(s int32, args *rpc.GetArgs, reply *rpc.GetReply) (NetworkReply, interface{}, rpc.Err) {
+	deadline := time.After(rpcTimeout * time.Millisecond)
 	resChan := make(chan bool, 1)
 
 	utils.DPrintf("[shardgrp/clerk] Calling callGet for %v", args)
@@ -50,16 +50,16 @@ func (ck *Clerk) callGet(s int32, args *rpc.GetArgs, reply *rpc.GetReply) (Netwo
 	select {
 	case ok := <-resChan:
 		if ok {
-			return OK, reply.Err
+			return OK, *reply, reply.Err
 		}
-		return DISCONNECT, reply.Err
+		return DISCONNECT, *reply, reply.Err
 	case <-deadline:
-		return TIMEOUT, rpc.OK
+		return TIMEOUT, *reply, rpc.OK
 	}
 }
 
-func (ck *Clerk) callPut(s int32, args *rpc.PutArgs, reply *rpc.PutReply) (NetworkReply, rpc.Err) {
-	deadline := time.After(rpcTimeout * time.Second)
+func (ck *Clerk) callPut(s int32, args *rpc.PutArgs, reply *rpc.PutReply) (NetworkReply, interface{}, rpc.Err) {
+	deadline := time.After(rpcTimeout * time.Millisecond)
 	resChan := make(chan bool, 1)
 
 	utils.DPrintf("[shardgrp/clerk] Calling callPut for %v", args)
@@ -72,19 +72,19 @@ func (ck *Clerk) callPut(s int32, args *rpc.PutArgs, reply *rpc.PutReply) (Netwo
 	select {
 	case ok := <-resChan:
 		if ok {
-			return OK, reply.Err
+			return OK, *reply, reply.Err
 		}
-		return DISCONNECT, reply.Err
+		return DISCONNECT, *reply, reply.Err
 	case <-deadline:
-		return TIMEOUT, rpc.OK
+		return TIMEOUT, *reply, rpc.OK
 	}
 }
 
-func (ck *Clerk) callFreezeShard(s int32, args *shardrpc.FreezeShardArgs, reply *shardrpc.FreezeShardReply) (NetworkReply, rpc.Err) {
-	deadline := time.After(rpcTimeout * time.Second)
+func (ck *Clerk) callFreezeShard(s int32, args *shardrpc.FreezeShardArgs, reply *shardrpc.FreezeShardReply) (NetworkReply, interface{}, rpc.Err) {
+	deadline := time.After(rpcTimeout * time.Millisecond)
 	resChan := make(chan bool, 1)
 
-	// utils.DPrintf("Calling callFreezeShard for %v", args)
+	utils.DPrintf("Calling callFreezeShard for %v", args)
 
 	go func() {
 		ok := ck.clnt.Call(ck.servers[s], "KVServer.FreezeShard", args, reply)
@@ -94,16 +94,19 @@ func (ck *Clerk) callFreezeShard(s int32, args *shardrpc.FreezeShardArgs, reply 
 	select {
 	case ok := <-resChan:
 		if ok {
-			return OK, reply.Err
+			utils.DPrintf("[shardgrp/clerk] callFreezeShard successful for shardId=%d, num=%d, reply=%v", args.Shard, args.Num, *reply)
+			return OK, *reply, reply.Err
 		}
-		return DISCONNECT, reply.Err
+		utils.DPrintf("[shardgrp/clerk] callFreezeShard failed for shardId=%d, num=%d", args.Shard, args.Num)
+		return DISCONNECT, *reply, reply.Err
 	case <-deadline:
-		return TIMEOUT, rpc.OK
+		utils.DPrintf("[shardgrp/clerk] callFreezeShard timeout for shardId=%d, num=%d", args.Shard, args.Num)
+		return TIMEOUT, *reply, rpc.OK
 	}
 }
 
-func (ck *Clerk) callInstallShard(s int32, args *shardrpc.InstallShardArgs, reply *shardrpc.InstallShardReply) (NetworkReply, rpc.Err) {
-	deadline := time.After(rpcTimeout * time.Second)
+func (ck *Clerk) callInstallShard(s int32, args *shardrpc.InstallShardArgs, reply *shardrpc.InstallShardReply) (NetworkReply, interface{}, rpc.Err) {
+	deadline := time.After(rpcTimeout * time.Millisecond)
 	resChan := make(chan bool, 1)
 
 	utils.DPrintf("[shardgrp/clerk] Calling callInstallShard for shardId=%d, num=%d", args.Shard, args.Num)
@@ -116,16 +119,19 @@ func (ck *Clerk) callInstallShard(s int32, args *shardrpc.InstallShardArgs, repl
 	select {
 	case ok := <-resChan:
 		if ok {
-			return OK, reply.Err
+			utils.DPrintf("[shardgrp/clerk] callInstallShard successful for shardId=%d, num=%d, reply=%v", args.Shard, args.Num, *reply)
+			return OK, *reply, reply.Err
 		}
-		return DISCONNECT, reply.Err
+		utils.DPrintf("[shardgrp/clerk] callInstallShard failed for shardId=%d, num=%d", args.Shard, args.Num)
+		return DISCONNECT, *reply, reply.Err
 	case <-deadline:
-		return TIMEOUT, rpc.OK
+		utils.DPrintf("[shardgrp/clerk] callInstallShard timeout for shardId=%d, num=%d", args.Shard, args.Num)
+		return TIMEOUT, *reply, rpc.OK
 	}
 }
 
-func (ck *Clerk) callDeleteShard(s int32, args *shardrpc.DeleteShardArgs, reply *shardrpc.DeleteShardReply) (NetworkReply, rpc.Err) {
-	deadline := time.After(rpcTimeout * time.Second)
+func (ck *Clerk) callDeleteShard(s int32, args *shardrpc.DeleteShardArgs, reply *shardrpc.DeleteShardReply) (NetworkReply, interface{}, rpc.Err) {
+	deadline := time.After(rpcTimeout * time.Millisecond)
 	resChan := make(chan bool, 1)
 
 	utils.DPrintf("[shardgrp/clerk] Calling callDeleteShard for shardId=%d, num=%d", args.Shard, args.Num)
@@ -138,18 +144,21 @@ func (ck *Clerk) callDeleteShard(s int32, args *shardrpc.DeleteShardArgs, reply 
 	select {
 	case ok := <-resChan:
 		if ok {
-			return OK, reply.Err
+			utils.DPrintf("[shardgrp/clerk] callDeleteShard successful for shardId=%d, num=%d, reply=%v", args.Shard, args.Num, *reply)
+			return OK, *reply, reply.Err
 		}
-		return DISCONNECT, reply.Err
+		utils.DPrintf("[shardgrp/clerk] callDeleteShard failed for shardId=%d, num=%d", args.Shard, args.Num)
+		return DISCONNECT, *reply, reply.Err
 	case <-deadline:
-		return TIMEOUT, rpc.OK
+		utils.DPrintf("[shardgrp/clerk] callDeleteShard timeout for shardId=%d, num=%d", args.Shard, args.Num)
+		return TIMEOUT, *reply, rpc.OK
 	}
 }
 
 // retry logic
-func (ck *Clerk) sendReqToMaster(rpcCaller func(s int32) (NetworkReply, rpc.Err)) rpc.Err {
+func (ck *Clerk) sendReqToMaster(rpcCaller func(s int32) (NetworkReply, interface{}, rpc.Err)) (interface{}, rpc.Err) {
 	currentLeader := ck.leader.Load()
-	ntReply, rpcErr := rpcCaller(currentLeader)
+	ntReply, resp, rpcErr := rpcCaller(currentLeader)
 	utils.DPrintf("[shardgrp/clerk] sendReqToMaster response: ntReply=%v, rpcErr=%v", ntReply, rpcErr)
 	hadLostCalls := ntReply == TIMEOUT || ntReply == DISCONNECT
 	// partition := ntReply == DISCONNECT
@@ -161,32 +170,32 @@ func (ck *Clerk) sendReqToMaster(rpcCaller func(s int32) (NetworkReply, rpc.Err)
 		for {
 			partitions := 0
 			for idx := range ck.servers {
-				ntReply, rpcErr := rpcCaller(int32(idx))
+				ntReply, resp, rpcErr := rpcCaller(int32(idx))
 				utils.DPrintf("[shardgrp/clerk] sendReqToMaster response: ntReply=%v, rpcErr=%v", ntReply, rpcErr)
 
 				if ntReply == OK {
 					switch rpcErr {
 					case rpc.OK:
 						ck.leader.CompareAndSwap(currentLeader, int32(idx))
-						return rpc.OK
+						return resp, rpc.OK
 					case rpc.ErrVersion:
 						// the first call failed, we don't know if the Put was performed or not, return ErrMaybe
 						ck.leader.CompareAndSwap(currentLeader, int32(idx))
 						if hadLostCalls {
-							return rpc.ErrMaybe
+							return resp, rpc.ErrMaybe
 						}
-						return rpc.ErrVersion
+						return resp, rpc.ErrVersion
 					case rpc.ErrWrongLeader:
 						// try the next server
 						continue
 					case rpc.ErrWrongGroup:
 						if hadLostCalls {
-							return rpc.ErrMaybe
+							return resp, rpc.ErrMaybe
 						}
-						return rpc.ErrWrongGroup
+						return resp, rpc.ErrWrongGroup
 					default:
 						// some other error, return it
-						return rpcErr
+						return resp, rpcErr
 					}
 				} else if ntReply == TIMEOUT {
 					utils.DPrintf("[shardgrp/clerk] Timeout to server = %v", ck.servers[idx])
@@ -197,101 +206,111 @@ func (ck *Clerk) sendReqToMaster(rpcCaller func(s int32) (NetworkReply, rpc.Err)
 				}
 			}
 			if partitions == len(ck.servers) {
-				utils.DPrintf("[shardgrp/clerk] All servers are partitioned, retrying")
-				return rpc.ErrMaybe
+				utils.DPrintf("[shardgrp/clerk] All servers are partitioned, returning ErrMaybe")
+				return resp, rpc.ErrMaybe
 			}
 			time.Sleep(20 * time.Millisecond)
 		}
 	}
 
-	return rpcErr
+	return resp, rpcErr
 }
 
 func (ck *Clerk) Get(key string) (string, rpc.Tversion, rpc.Err) {
 	args := rpc.GetArgs{Key: key}
-	reply := rpc.GetReply{Value: "", Version: 0, Err: rpc.OK}
 
-	rpcCaller := func(s int32) (NetworkReply, rpc.Err) {
+	rpcCaller := func(s int32) (NetworkReply, interface{}, rpc.Err) {
+		reply := rpc.GetReply{Value: "", Version: 0, Err: rpc.OK}
 		return ck.callGet(s, &args, &reply)
 	}
 
-	rpcErr := ck.sendReqToMaster(rpcCaller)
+	resp, rpcErr := ck.sendReqToMaster(rpcCaller)
 
 	if rpcErr != rpc.OK {
 		return "", 0, rpcErr
 	}
 
-	return reply.Value, reply.Version, reply.Err
+	castedResp := resp.(rpc.GetReply)
+	utils.DPrintf("[shardgrp/clerk] Get: done calling callGet with rpcErr=%v and reply.Err=%v", rpcErr, castedResp.Err)
+	return castedResp.Value, castedResp.Version, castedResp.Err
 }
 
 func (ck *Clerk) Put(key string, value string, version rpc.Tversion) rpc.Err {
 	args := rpc.PutArgs{Key: key, Value: value, Version: version}
-	reply := rpc.PutReply{Err: rpc.OK}
 
 	utils.DPrintf("[shardgrp/clerk] Put: key=%s, value=%s, version=%d", key, value, version)
 
-	rpcCaller := func(s int32) (NetworkReply, rpc.Err) {
+	rpcCaller := func(s int32) (NetworkReply, interface{}, rpc.Err) {
+		reply := rpc.PutReply{Err: rpc.OK}
 		return ck.callPut(s, &args, &reply)
 	}
 
-	rpcErr := ck.sendReqToMaster(rpcCaller)
-
-	utils.DPrintf("[shardgrp/clerk] Put: done calling callPut with rpcErr=%v and reply.Err=%v", rpcErr, reply.Err)
+	resp, rpcErr := ck.sendReqToMaster(rpcCaller)
 
 	if rpcErr != rpc.OK {
 		return rpcErr
 	}
 
-	return reply.Err
+	castedResp := resp.(rpc.PutReply)
+	utils.DPrintf("[shardgrp/clerk] Put: done calling callPut with rpcErr=%v and reply.Err=%v", rpcErr, castedResp.Err)
+	return castedResp.Err
 }
 
 func (ck *Clerk) FreezeShard(s shardcfg.Tshid, num shardcfg.Tnum) ([]byte, rpc.Err) {
 	args := shardrpc.FreezeShardArgs{Shard: s, Num: num}
-	reply := shardrpc.FreezeShardReply{Num: 0, State: nil, Err: rpc.OK}
 
-	rpcCaller := func(s int32) (NetworkReply, rpc.Err) {
+	rpcCaller := func(s int32) (NetworkReply, interface{}, rpc.Err) {
+		reply := shardrpc.FreezeShardReply{Num: 0, State: nil, Err: rpc.OK}
 		return ck.callFreezeShard(s, &args, &reply)
 	}
 
-	rpcErr := ck.sendReqToMaster(rpcCaller)
+	resp, rpcErr := ck.sendReqToMaster(rpcCaller)
 
 	if rpcErr != rpc.OK {
 		return nil, rpcErr
 	}
 
-	return reply.State, reply.Err
+	castedResp := resp.(shardrpc.FreezeShardReply)
+	utils.DPrintf("[shardgrp/clerk] FreezeShard: done calling callFreezeShard with rpcErr=%v and reply.Err=%v", rpcErr, castedResp.Err)
+	return castedResp.State, castedResp.Err
 }
 
 func (ck *Clerk) InstallShard(s shardcfg.Tshid, state []byte, num shardcfg.Tnum) rpc.Err {
 	args := shardrpc.InstallShardArgs{Shard: s, State: state, Num: num}
-	reply := shardrpc.InstallShardReply{Err: rpc.OK}
 
-	rpcCaller := func(s int32) (NetworkReply, rpc.Err) {
+	rpcCaller := func(s int32) (NetworkReply, interface{}, rpc.Err) {
+		reply := shardrpc.InstallShardReply{Err: rpc.OK}
 		return ck.callInstallShard(s, &args, &reply)
 	}
 
-	rpcErr := ck.sendReqToMaster(rpcCaller)
+	resp, rpcErr := ck.sendReqToMaster(rpcCaller)
 
 	if rpcErr != rpc.OK {
 		return rpcErr
 	}
 
-	return reply.Err
+	castedResp := resp.(shardrpc.InstallShardReply)
+	utils.DPrintf("[shardgrp/clerk] InstallShard: done calling callInstallShard with rpcErr=%v and reply.Err=%v", rpcErr, castedResp.Err)
+	return castedResp.Err
 }
 
 func (ck *Clerk) DeleteShard(s shardcfg.Tshid, num shardcfg.Tnum) rpc.Err {
 	args := shardrpc.DeleteShardArgs{Shard: s, Num: num}
-	reply := shardrpc.DeleteShardReply{Err: rpc.OK}
 
-	rpcCaller := func(s int32) (NetworkReply, rpc.Err) {
+	rpcCaller := func(s int32) (NetworkReply, interface{}, rpc.Err) {
+		reply := shardrpc.DeleteShardReply{Err: rpc.OK}
 		return ck.callDeleteShard(s, &args, &reply)
 	}
 
-	rpcErr := ck.sendReqToMaster(rpcCaller)
+	resp, rpcErr := ck.sendReqToMaster(rpcCaller)
 
+	// infra error
 	if rpcErr != rpc.OK {
 		return rpcErr
 	}
 
-	return reply.Err
+	// operation result
+	castedResp := resp.(shardrpc.DeleteShardReply)
+	utils.DPrintf("[shardgrp/clerk] DeleteShard: done calling callDeleteShard with rpcErr=%v and reply.Err=%v", rpcErr, castedResp.Err)
+	return castedResp.Err
 }

--- a/src/shardkv1/shardgrp/server.go
+++ b/src/shardkv1/shardgrp/server.go
@@ -1,6 +1,5 @@
 package shardgrp
 
-// TestManyConcurrentClerkUnreliable5A
 
 import (
 	"bytes"
@@ -90,7 +89,6 @@ func (kv *KVServer) handleGetOp(args *rpc.GetArgs) GetOpResult {
 	utils.DPrintf("[server=%d, gid=%d, handleGetOp: shard=%d] key=%v is on shard=%d",
 		kv.me, kv.gid, kv.lastSeenConfigNum, args.Key, shId)
 
-
 	db, err := kv.getShardDb(shId)
 	if err != rpc.OK {
 		utils.DPrintf("[server=%d, gid=%d, handleGetOp: shard=%d] key=%v is on shard=%d. The group is not the owner of the shard.",
@@ -174,7 +172,6 @@ func (kv *KVServer) handleFreezeShardOp(args *shardrpc.FreezeShardArgs) FreezeSh
 	if args.Num < kv.lastSeenConfigNum[args.Shard] {
 		return FreezeShardOpResult{Err: rpc.OK}
 	}
-	kv.lastSeenConfigNum[args.Shard] = args.Num
 
 	// if no db, probably no op, just continue
 	db, err := kv.getShardDb(args.Shard)
@@ -184,6 +181,8 @@ func (kv *KVServer) handleFreezeShardOp(args *shardrpc.FreezeShardArgs) FreezeSh
 	}
 
 	kv.frozenShards[args.Shard] = struct{}{}
+
+	kv.lastSeenConfigNum[args.Shard] = args.Num
 
 	utils.DPrintf("[server=%d, gid=%d, handleFreezeShardOp: shard=%d, num=%d, lastSeenConfigNum=%d]. Returning state %v",
 		kv.me, kv.gid, args.Shard, args.Num, kv.lastSeenConfigNum, db)
@@ -212,19 +211,18 @@ func (kv *KVServer) handleInstallShardOp(args *shardrpc.InstallShardArgs) Instal
 		kv.me, kv.gid, args.Shard, args.Num, kv.lastSeenConfigNum, db)
 
 	// verify leniariz for the shard. if outdated -> OK
-	// it should be impossible to install a shard for the Num twice
 	if args.Num <= kv.lastSeenConfigNum[args.Shard] {
 		// panic("Received FreezeShard request with old config num, idk how to handle it yet")
 		utils.DPrintf("[server=%d, gid=%d, handleInstallShardOp: shard=%d, num=%d, lastSeenConfigNum=%d] returning no op",
 			kv.me, kv.gid, args.Shard, args.Num, kv.lastSeenConfigNum)
 		return InstallShardOpResult{Err: rpc.OK}
 	}
-	kv.lastSeenConfigNum[args.Shard] = args.Num
-
 	kv.db[args.Shard] = db
 
 	// unfroze if some stale operation have not complete the process and the shard is frozen
 	delete(kv.frozenShards, args.Shard)
+
+	kv.lastSeenConfigNum[args.Shard] = args.Num
 
 	utils.DPrintf("[server=%d, gid=%d, handleInstallShardOp: shard=%d, num=%d, lastSeenConfigNum=%d] returning",
 		kv.me, kv.gid, args.Shard, args.Num, kv.lastSeenConfigNum)
@@ -246,11 +244,11 @@ func (kv *KVServer) handleDeleteShardOp(args *shardrpc.DeleteShardArgs) DeleteSh
 		}
 	}
 
-	// update version
-	kv.lastSeenConfigNum[args.Shard] = args.Num
-
 	delete(kv.db, args.Shard)
 	delete(kv.frozenShards, args.Shard)
+
+	// update version
+	kv.lastSeenConfigNum[args.Shard] = args.Num
 
 	return DeleteShardOpResult{
 		Err: rpc.OK,


### PR DESCRIPTION
Extend the shard controller to allow concurrent controllers. Add version verification to the shard controller. Add an in-memory last known config. Extend the shardkv client to work with a default config.